### PR TITLE
feat: Rework statement parsing for `pogo squash`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ def test_version(cli_runner):
     result = cli_runner.invoke(["--version"])
     assert result.exit_code == 0
 
-    assert result.output.strip() == f"pogo-migrate {version}"
+    cli_runner.assert_output(f"pogo-migrate {version}")
 
 
 @pytest.fixture()


### PR DESCRIPTION
Fix issue with incorrect identifier being picked up on ALTER statements.
Clean up how sqlparse library is used to search for tokens explicitly instead of looping over all tokens.

Refs: #15