### PR TITLE
fix: Detect incorrectly defined multiple dependencies in sql migrations.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ source = ["src/pogo_migrate"]
 [tool.ruff]
 target-version = "py39"
 line-length = 120
+output-format = "concise"
 
 [tool.ruff.lint]
 select = ["ALL"]

--- a/src/pogo_migrate/migration.py
+++ b/src/pogo_migrate/migration.py
@@ -30,7 +30,7 @@ def terminate_statements(statements: list[str]) -> list[str]:
     return statements
 
 
-def read_sql_migration(
+def read_sql_migration(  # noqa: C901
     path: Path,
 ) -> tuple[str, str, MigrationFunc, MigrationFunc, bool, list[str], list[str]]:
     """Read a sql migration.
@@ -49,6 +49,10 @@ def read_sql_migration(
 
         if m is None:
             msg = f"{path.name}: No '-- depends:' or message found."
+            raise exceptions.BadMigrationError(msg)
+
+        if metadata.count("-- depends:") > 1:
+            msg = f"{path.name}: Multiple '-- depends:' defined."
             raise exceptions.BadMigrationError(msg)
 
         message: str = m[1].strip()


### PR DESCRIPTION
Prevent sql migrations with incorrectly defined multiple dependencies from parsing and leading to red herring bad migrations due to missing tables etc.

closes #33 