### PR TITLE
fix: Read migrations dir from config, continue to support manual override in squash, remove, and validate.

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,8 @@ Supported flags:
 - `-d, --database-env-key` defines the environment variable (or template to
   build from environment variables) for the database dsn. See
   [configuration](https://nrwldev.github.io/pogo-migrate/configuration/) for
-  examples.
+  examples. For setups running migrations purely in code, this configuration
+  can be omitted.
 
 ### Migrating from yoyo
 
@@ -138,7 +139,7 @@ live databases have been updated.
 Supported flags:
 
 - `-m, --migrations-location` defines the name of the migrations folder
-  (defaults to `./migrations`)
+  (defaults to configured location)
 - `--backup` keep any removed files with `.bak` suffix.
 
 ### Squashing migrations
@@ -158,7 +159,7 @@ grouped first.
 Supported flags:
 
 - `-m, --migrations-location` defines the name of the migrations folder
-  (defaults to `./migrations`)
+  (defaults to configured location)
 - `--backup` keep any removed files with `.bak` suffix.
 - `--source` add a comment to each extracted statement with the source
   migration id.
@@ -178,7 +179,7 @@ commands.
 Supported flags:
 
 - `-m, --migrations-location` defines the name of the migrations folder
-  (defaults to `./migrations`)
+  (defaults to configured location)
 
 ## Validate migration sql
 
@@ -189,7 +190,7 @@ using reserved keywords as table names without quoting etc.
 Supported flags:
 
 - `-m, --migrations-location` defines the name of the migrations folder
-  (defaults to `./migrations`)
+  (defaults to configured location)
 
 ## Usage in python
 

--- a/src/pogo_migrate/cli.py
+++ b/src/pogo_migrate/cli.py
@@ -442,7 +442,7 @@ def rollback(
 @app.command("remove")
 def remove(
     migration_id: str = typer.Argument(show_default=False, help="Migration id to remove (message can be excluded)."),
-    migrations_location: str = typer.Option("./migrations", "-m", "--migrations-location"),
+    migrations_location: t.Optional[str] = typer.Option(None, "-m", "--migrations-location"),
     *,
     backup: bool = typer.Option(False, "--backup/ ", help="Keep .bak copy of original files."),  # noqa: FBT003
     verbose: int = typer.Option(
@@ -456,6 +456,10 @@ def remove(
 ) -> None:
     """Remove a migration from the dependency chain."""
     context = Context(verbose)
+
+    load_dotenv()
+    config = load_config()
+    migrations_location = migrations_location or str(config.migrations)
 
     migrations = [
         Migration(path.stem, path, set())
@@ -474,7 +478,7 @@ def remove(
 
 @app.command("squash")
 def squash_(  # noqa: C901, PLR0912, PLR0915, PLR0913
-    migrations_location: str = typer.Option("./migrations", "-m", "--migrations-location"),
+    migrations_location: t.Optional[str] = typer.Option(None, "-m", "--migrations-location"),
     *,
     backup: bool = typer.Option(False, "--backup/ ", help="Keep .bak copy of original files."),  # noqa: FBT003
     source: bool = typer.Option(False, "--source/ ", help="Add comment for source migration to each statement."),  # noqa: FBT003
@@ -504,6 +508,10 @@ def squash_(  # noqa: C901, PLR0912, PLR0915, PLR0913
     grouped first.
     """
     context = Context(verbose)
+
+    load_dotenv()
+    config = load_config()
+    migrations_location = migrations_location or str(config.migrations)
 
     migrations = [
         Migration(path.stem, path, set())
@@ -637,7 +645,7 @@ def squash_(  # noqa: C901, PLR0912, PLR0915, PLR0913
 
 @app.command("clean")
 def clean(
-    migrations_location: str = typer.Option("./migrations", "-m", "--migrations-location"),
+    migrations_location: t.Optional[str] = typer.Option(None, "-m", "--migrations-location"),
     *,
     verbose: int = typer.Option(
         0,
@@ -650,6 +658,9 @@ def clean(
 ) -> None:
     """Clean the migration directory of .bak migrations from squash."""
     _context = Context(verbose)
+    load_dotenv()
+    config = load_config()
+    migrations_location = migrations_location or str(config.migrations)
 
     for path in Path(migrations_location).iterdir():
         if path.suffix in {".bak"}:
@@ -658,7 +669,7 @@ def clean(
 
 @app.command("validate")
 def validate(
-    migrations_location: str = typer.Option("./migrations", "-m", "--migrations-location"),
+    migrations_location: t.Optional[str] = typer.Option(None, "-m", "--migrations-location"),
     *,
     verbose: int = typer.Option(
         0,
@@ -674,6 +685,9 @@ def validate(
     Best effort pass through to make sure identifiers aren't keywords.
     """
     context = Context(verbose)
+    load_dotenv()
+    config = load_config()
+    migrations_location = migrations_location or str(config.migrations)
 
     migrations = [
         Migration(path.stem, path, set())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1959,6 +1959,7 @@ class TestMigrateYoyo:
         )
 
 
+@pytest.mark.usefixtures("pyproject")
 class TestRemove:
     def test_migration_removed_from_chain(self, migration_file_factory, cli_runner):
         migration_file_factory(
@@ -2020,6 +2021,7 @@ class TestRemove:
         assert Path(f"{mp}.bak").exists() is True
 
 
+@pytest.mark.usefixtures("pyproject")
 class TestClean:
     def test_bak_files_removed(self, migration_file_factory, cli_runner):
         b1 = migration_file_factory(
@@ -2064,6 +2066,7 @@ class TestClean:
         assert mp.exists() is True
 
 
+@pytest.mark.usefixtures("pyproject")
 class TestSquash:
     def test_simple_squash_all_sql(self, migration_file_factory, cli_runner):
         old = migration_file_factory(


### PR DESCRIPTION
closes #45 